### PR TITLE
Migrate EFCore 3.1 - Add additional support for distinct

### DIFF
--- a/src/SpecificatR.Infrastructure.Abstractions/Contracts/BaseSpecification.cs
+++ b/src/SpecificatR.Infrastructure.Abstractions/Contracts/BaseSpecification.cs
@@ -1,118 +1,133 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="BaseSpecification.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+//-----------------------------------------------------------------------
+// <copyright file="BaseSpecification.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:46</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Abstractions
+namespace SpecificatR.Abstractions
 {
     using System;
     using System.Collections.Generic;
     using System.Linq.Expressions;
 
     /// <summary>
-    /// Defines the <see cref="BaseSpecification{TEntity}" />
+    /// Defines the <see cref="BaseSpecification{TEntity}"/>.
     /// </summary>
-    /// <typeparam name="TEntity"></typeparam>
+    /// <typeparam name="TEntity">The Entity Type <see cref="TEntity"/>.</typeparam>
     public abstract class BaseSpecification<TEntity> : ISpecification<TEntity>
     {
         /// <summary>
-        /// Defines the _includes
+        /// Defines the _includes.
         /// </summary>
         private readonly HashSet<Expression<Func<TEntity, object>>> _includes = new HashSet<Expression<Func<TEntity, object>>>();
 
         /// <summary>
-        /// Defines the _orderByExpressions
+        /// Defines the _orderByExpressions.
         /// </summary>
         private readonly HashSet<OrderByExpression<TEntity>> _orderByExpressions = new HashSet<OrderByExpression<TEntity>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseSpecification{TEntity}"/> class.
         /// </summary>
-        /// <param name="criteria">The criteria<see cref="Expression{Func{TEntity, bool}}"/></param>
+        /// <param name="criteria">
+        /// The criteria <see cref="Expression{Func{TEntity, bool}}"/> Sets the criteria to use the
+        /// where statement in the Linq query.
+        /// </param>
         protected BaseSpecification(Expression<Func<TEntity, bool>> criteria)
         {
             Criteria = criteria;
         }
 
         /// <summary>
-        /// Gets a value indicating whether AsTracking
+        /// Gets a value indicating whether AsTracking.
         /// </summary>
         public bool AsTracking { get; private set; } = false;
 
         /// <summary>
-        /// Gets a value indicating whether to only return different values
+        /// Gets a value indicating whether to only return different values.
         /// </summary>
         public bool AsDistinct { get; private set; } = false;
 
         /// <summary>
-        /// Gets the Criteria
+        /// Gets the Criteria.
         /// </summary>
         public Expression<Func<TEntity, bool>> Criteria { get; }
 
         /// <summary>
-        /// Gets a value indicating whether IgnoreQueryFilters
+        /// Gets a value indicating whether IgnoreQueryFilters.
         /// </summary>
         public bool IgnoreQueryFilters { get; private set; } = false;
 
         /// <summary>
-        /// Gets the Includes
+        /// Gets the Includes.
         /// </summary>
         public IReadOnlyCollection<Expression<Func<TEntity, object>>> Includes => _includes;
 
         /// <summary>
-        /// Gets a value indicating whether IsPagingEnabled
+        /// Gets a value indicating whether IsPagingEnabled.
         /// </summary>
         public bool IsPagingEnabled { get; private set; } = false;
 
         /// <summary>
-        /// Gets the OrderByExpressions
+        /// Gets the OrderByExpressions.
         /// </summary>
         public IReadOnlyCollection<OrderByExpression<TEntity>> OrderByExpressions => _orderByExpressions;
 
         /// <summary>
-        /// Gets the Skip
+        /// Gets the Skip.
         /// </summary>
         public int Skip { get; private set; }
 
         /// <summary>
-        /// Gets the Take
+        /// Gets the Take.
         /// </summary>
         public int Take { get; private set; }
 
+        public IEqualityComparer<TEntity> DistinctComparer { get; private set; }
+
         /// <summary>
-        /// Ignore query filters
-        /// <para>If entities are set with additional QueryFilters (<see cref="https://docs.microsoft.com/en-us/ef/core/querying/filters"/>), <c>IgnoreQueryFilters</c> can be used to ignore these set QueryFilters</para>
+        /// Ignore query filters.
+        /// <para>
+        /// If entities are set with additional QueryFilters ( <see
+        /// cref="https://docs.microsoft.com/en-us/ef/core/querying/filters"/>),
+        /// <c>IgnoreQueryFilters</c> can be used to ignore these set QueryFilters.
+        /// </para>
         /// </summary>
         protected virtual void AddIgnoreQueryFilters()
             => IgnoreQueryFilters = true;
 
         /// <summary>
         /// To add Specific related entities to include in the query results.
-        /// <para>Example: <code>AddInclude(customer => customer.Addresses.Select(address => address.Country);</code></para>
+        /// <para>Example:
+        /// <code>AddInclude(customer =&gt; customer.Addresses.Select(address =&gt; address.Country);</code>
+        /// </para>
         /// </summary>
-        /// <param name="includeExpression"></param>
+        /// <param name="includeExpression">Expression of what should be included.</param>
         protected virtual void AddInclude(Expression<Func<TEntity, object>> includeExpression)
             => _includes.Add(includeExpression);
 
         /// <summary>
-        /// Adding ordering to the query. First orderby is the first to be handled. Every additional <c>AddOrderBy()</c> will be executed in same order.
-        /// <para>Example: <code>AddOrderBy(x => x.Id, OrderByDirection.Ascending);</code></para>
+        /// Adding ordering to the query. First orderby is the first to be handled. Every additional
+        /// <c>AddOrderBy()</c> will be executed in same order.
+        /// <para>Example:
+        /// <code>AddOrderBy(x =&gt; x.Id, OrderByDirection.Ascending);</code>
+        /// </para>
         /// </summary>
-        /// <param name="orderByExpression"></param>
-        /// <param name="orderByDirection"></param>
+        /// <param name="orderByExpression">Expression stating on what the ordering should be done.</param>
+        /// <param name="orderByDirection"> Direction in wich it should be ordered.</param>
         protected virtual void AddOrderBy(Expression<Func<TEntity, object>> orderByExpression, OrderByDirection orderByDirection)
             => _orderByExpressions.Add(new OrderByExpression<TEntity>(orderByExpression, orderByDirection));
 
         /// <summary>
         /// Apply Paging to the query.
-        /// <para>This will add a skip and take to the query based on the parameters (<c>pageIndex</c> and <c>pageSize</c></para>
+        /// <para>
+        /// This will add a skip and take to the query based on the parameters ( <c>pageIndex</c>
+        /// and <c>pageSize</c>.
+        /// </para>
         /// </summary>
-        /// <param name="pageIndex"></param>
-        /// <param name="pageSize"></param>
+        /// <param name="pageIndex">Index of the page.</param>
+        /// <param name="pageSize"> The count of the page.</param>
         protected virtual void ApplyPaging(int pageIndex, int pageSize)
         {
             Take = pageSize;
@@ -121,15 +136,31 @@ namespace SpecificatR.Infrastructure.Abstractions
         }
 
         /// <summary>
-        /// Set retrieved query as tracking in EF Core. By default queries will not be tracked with specifications (AsNoTracking).
+        /// Set retrieved query as tracking in EF Core. By default queries will not be tracked with
+        /// specifications (AsNoTracking).
         /// </summary>
         protected virtual void ApplyTracking()
             => AsTracking = true;
 
         /// <summary>
-        /// Set query as distinct in EF Core. By default queries will not be distinct with specifications (AsDistinct).
+        /// Set query as distinct in EF Core. By default queries will not be distinct with
+        /// specifications (AsDistinct) using a custom or default comparer.
+        /// </summary>
+        /// <param name="comparer">The comparer that should be used to set the distinct list.</param>
+        protected virtual void ApplyDistinct(IEqualityComparer<TEntity> comparer)
+        {
+            AsDistinct = true;
+            DistinctComparer = comparer;
+        }
+
+        /// <summary>
+        /// Set query as distinct in EF Core. By default queries will not be distinct with
+        /// specifications (AsDistinct).
         /// </summary>
         protected virtual void ApplyDistinct()
-            => AsDistinct = true;
+        {
+            AsDistinct = true;
+            DistinctComparer = null;
+        }
     }
 }

--- a/src/SpecificatR.Infrastructure.Abstractions/Contracts/OrderByExpression.cs
+++ b/src/SpecificatR.Infrastructure.Abstractions/Contracts/OrderByExpression.cs
@@ -1,28 +1,26 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="OrderByExpression.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+//-----------------------------------------------------------------------
+// <copyright file="OrderByExpression.cs" >
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:46</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Abstractions
+namespace SpecificatR.Abstractions
 {
     using System;
     using System.Linq.Expressions;
 
     /// <summary>
-    /// Defines the <see cref="OrderByExpression{T}" />
+    /// Defines the <see cref="OrderByExpression{T}"/>.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">Is the class type of <see cref="T"/>.</typeparam>
     public class OrderByExpression<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderByExpression{T}"/> class.
         /// </summary>
-        /// <param name="expression">The expression<see cref="Expression{Func{T, object}}"/></param>
-        /// <param name="orderByDirection">The orderByDirection<see cref="OrderByDirection"/></param>
+        /// <param name="expression">      The expression <see cref="Expression{Func{T, object}}"/>.</param>
+        /// <param name="orderByDirection">The orderByDirection <see cref="OrderByDirection"/>.</param>
         public OrderByExpression(Expression<Func<T, object>> expression, OrderByDirection orderByDirection)
         {
             Expression = expression;
@@ -30,12 +28,12 @@ namespace SpecificatR.Infrastructure.Abstractions
         }
 
         /// <summary>
-        /// Gets or sets the Expression
+        /// Gets or sets the Expression.
         /// </summary>
         public Expression<Func<T, object>> Expression { get; set; }
 
         /// <summary>
-        /// Gets or sets the OrderByDirection
+        /// Gets or sets the OrderByDirection.
         /// </summary>
         public OrderByDirection OrderByDirection { get; set; }
     }

--- a/src/SpecificatR.Infrastructure.Abstractions/Enums/OrderByDirection.cs
+++ b/src/SpecificatR.Infrastructure.Abstractions/Enums/OrderByDirection.cs
@@ -1,13 +1,11 @@
 //-----------------------------------------------------------------------
-// <copyright file="OrderByDirection.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="OrderByDirection.cs" >
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:46</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Abstractions
+namespace SpecificatR.Abstractions
 {
     /// <summary>
     /// Defines the OrderByDirection.

--- a/src/SpecificatR.Infrastructure.Abstractions/Interfaces/IBaseEntity.cs
+++ b/src/SpecificatR.Infrastructure.Abstractions/Interfaces/IBaseEntity.cs
@@ -1,22 +1,20 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="IBaseEntity.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+//-----------------------------------------------------------------------
+// <copyright file="IBaseEntity.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:47</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Abstractions
+namespace SpecificatR.Abstractions
 {
     /// <summary>
-    /// Defines the <see cref="IBaseEntity{TIdentifier}" />
+    /// Defines the <see cref="IBaseEntity{TIdentifier}"/>.
     /// </summary>
-    /// <typeparam name="TIdentifier"></typeparam>
+    /// <typeparam name="TIdentifier">The Type identifier <see cref="TIdentifier"/>.</typeparam>
     public interface IBaseEntity<TIdentifier>
     {
         /// <summary>
-        /// Gets or sets the Id
+        /// Gets or sets the Id.
         /// </summary>
         TIdentifier Id { get; set; }
     }

--- a/src/SpecificatR.Infrastructure.Abstractions/Interfaces/ISpecification.cs
+++ b/src/SpecificatR.Infrastructure.Abstractions/Interfaces/ISpecification.cs
@@ -1,20 +1,18 @@
 //-----------------------------------------------------------------------
-// <copyright file="ISpecification.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="ISpecification.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:47</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Abstractions
+namespace SpecificatR.Abstractions
 {
     using System;
     using System.Collections.Generic;
     using System.Linq.Expressions;
 
     /// <summary>
-    /// Defines the <see cref="ISpecification{ClassType}" />.
+    /// Defines the <see cref="ISpecification{ClassType}"/>.
     /// </summary>
     /// <typeparam name="TClass">The <see cref="TClass"/>.</typeparam>
     public interface ISpecification<TClass>
@@ -28,6 +26,11 @@ namespace SpecificatR.Infrastructure.Abstractions
         /// Gets a value indicating whether to only return different values.
         /// </summary>
         bool AsDistinct { get; }
+
+        /// <summary>
+        /// Gets a comparer to set comparing rules to get a distinct result.
+        /// </summary>
+        IEqualityComparer<TClass> DistinctComparer { get; }
 
         /// <summary>
         /// Gets the Criteria.

--- a/src/SpecificatR.Infrastructure.Abstractions/SpecificatR.Infrastructure.Abstractions.csproj
+++ b/src/SpecificatR.Infrastructure.Abstractions/SpecificatR.Infrastructure.Abstractions.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>Latest</LangVersion>
-    <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
-    <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>David Vanderheyden</Authors>
-    <Product>SpecificatR.Abstractions</Product>
-    <PackageId>SpecificatR.Abstractions</PackageId>
-    <Description>SpecificatR abstractions contains contracts, enum and interfaces needed to use SpecificatR</Description>
+    <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
+    <Description>SpecificatR abstractions contains contracts, enums and interfaces needed to use SpecificatR.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>Latest</LangVersion>
+    <PackageId>SpecificatR.Abstractions</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Product>SpecificatR.Abstractions</Product>
+    <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
+    <Version>3.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpecificatR.Infrastructure.Abstractions/SpecificatR.Infrastructure.Abstractions.csproj
+++ b/src/SpecificatR.Infrastructure.Abstractions/SpecificatR.Infrastructure.Abstractions.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>Latest</LangVersion>
     <PackageId>SpecificatR.Abstractions</PackageId>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>SpecificatR.Abstractions</Product>
     <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
     <Version>3.0.0.0</Version>

--- a/src/SpecificatR.Infrastructure.UnitTest.Abstractions/SpecificatR.Infrastructure.UnitTest.Abstractions.csproj
+++ b/src/SpecificatR.Infrastructure.UnitTest.Abstractions/SpecificatR.Infrastructure.UnitTest.Abstractions.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>Latest</LangVersion>
-    <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
-    <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>David Vanderheyden</Authors>
-    <Product>SpecificatR.UnitTest.Abstractions</Product>
-    <PackageId>SpecificatR.UnitTest.Abstractions</PackageId>
-    <Description>SpecificatR UnitTest Abstractions contains all the essentials to unit test specifications created for use with SpecificatR</Description>
+    <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
+    <Description>SpecificatR UnitTest Abstractions contains all the essentials to unit test specifications created with SpecificatR.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>Latest</LangVersion>
+    <PackageId>SpecificatR.UnitTest.Abstractions</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Product>SpecificatR.UnitTest.Abstractions</Product>
+    <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
+    <Version>3.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpecificatR.Infrastructure.UnitTest.Abstractions/SpecificatR.Infrastructure.UnitTest.Abstractions.csproj
+++ b/src/SpecificatR.Infrastructure.UnitTest.Abstractions/SpecificatR.Infrastructure.UnitTest.Abstractions.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>Latest</LangVersion>
     <PackageId>SpecificatR.UnitTest.Abstractions</PackageId>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>SpecificatR.UnitTest.Abstractions</Product>
     <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
     <Version>3.0.0.0</Version>

--- a/src/SpecificatR.Infrastructure.UnitTest.Abstractions/SpecificationRepository.cs
+++ b/src/SpecificatR.Infrastructure.UnitTest.Abstractions/SpecificationRepository.cs
@@ -7,11 +7,11 @@
 // <date>25/05/2019 19:12:09</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.UnitTest.Abstractions
+namespace SpecificatR.UnitTest.Abstractions
 {
     using System.Linq;
     using System.Threading.Tasks;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
     using SpecificatR.Infrastructure.Internal;
 
     /// <summary>
@@ -30,7 +30,7 @@ namespace SpecificatR.Infrastructure.UnitTest.Abstractions
         /// <returns>The <see cref="Task{TEntity[]}"/>.</returns>
         public async Task<TEntity[]> GetAll(IQueryable<TEntity> queryable, ISpecification<TEntity> specification)
         {
-            var result = SpecificationResolver<TEntity>.GetResultSet(inputQuery: queryable, specification: specification);
+            TEntity[] result = SpecificationResolver<TEntity>.GetAllResult(inputQuery: queryable, specification: specification);
             return await Task.FromResult(result);
         }
 
@@ -40,9 +40,9 @@ namespace SpecificatR.Infrastructure.UnitTest.Abstractions
         /// <param name="queryable">    The queryable <see cref="IQueryable{TEntity}"/>.</param>
         /// <param name="specification">The specification <see cref="ISpecification{TEntity}"/>.</param>
         /// <returns>The <see cref="Task{TEntity}"/>.</returns>
-        public async Task<TEntity> GetSingleWithSpecification(IQueryable<TEntity> queryable, ISpecification<TEntity> specification)
+        public async Task<TEntity> GetFirstOrDefault(IQueryable<TEntity> queryable, ISpecification<TEntity> specification)
         {
-            var result = SpecificationResolver<TEntity>.GetSingleResult(inputQuery: queryable, specification: specification);
+            TEntity result = SpecificationResolver<TEntity>.GetFirstOrDefaultResult(inputQuery: queryable, specification: specification);
             return await Task.FromResult(result);
         }
     }

--- a/src/SpecificatR.Infrastructure/Configuration/SpecificatRServiceCollectionExtensions.cs
+++ b/src/SpecificatR.Infrastructure/Configuration/SpecificatRServiceCollectionExtensions.cs
@@ -1,29 +1,27 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="SpecificatRServiceCollectionExtensions.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+//-----------------------------------------------------------------------
+// <copyright file="SpecificatRServiceCollectionExtensions.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Configuration
 {
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.DependencyInjection;
-    using SpecificatR.Infrastructure.Repositories;
+    using SpecificatR;
 
     /// <summary>
-    /// Defines the <see cref="SpecificatRServiceCollectionExtensions" />
+    /// Defines the <see cref="SpecificatRServiceCollectionExtensions"/>.
     /// </summary>
     public static class SpecificatRServiceCollectionExtensions
     {
         /// <summary>
-        /// The AddSpecificatR
+        /// Service collection extension to add the specificatR setup registery to the DI container.
         /// </summary>
-        /// <typeparam name="TDbContext"></typeparam>
-        /// <param name="services">The services<see cref="IServiceCollection"/></param>
-        /// <returns>The <see cref="IServiceCollection"/></returns>
+        /// <typeparam name="TDbContext">The dbcontext <see cref="TDbContext"/>.</typeparam>
+        /// <param name="services">The services <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection AddSpecificatR<TDbContext>(this IServiceCollection services)
             where TDbContext : DbContext
         {

--- a/src/SpecificatR.Infrastructure/Internal/IncludeExpressionResolver.cs
+++ b/src/SpecificatR.Infrastructure/Internal/IncludeExpressionResolver.cs
@@ -1,10 +1,8 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="IncludeExpressionResolver.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+//-----------------------------------------------------------------------
+// <copyright file="IncludeExpressionResolver.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Internal
@@ -14,19 +12,21 @@ namespace SpecificatR.Infrastructure.Internal
     using System.Linq.Expressions;
 
     /// <summary>
-    /// Defines the <see cref="IncludeExpressionResolver" />
+    /// Defines the <see cref="IncludeExpressionResolver"/>.
     /// </summary>
     internal static class IncludeExpressionResolver
     {
         /// <summary>
-        /// The Resolve
+        /// Resolve Include expressions to strings for use on multiple levels.
         /// </summary>
-        /// <typeparam name="TEntity"></typeparam>
-        /// <param name="includeExpression">The includeExpression<see cref="Expression{Func{TEntity, object}}"/></param>
-        /// <returns>The <see cref="string"/></returns>
+        /// <typeparam name="TEntity">The entity type <see cref="TEntity"/>.</typeparam>
+        /// <param name="includeExpression">
+        /// The includeExpression <see cref="Expression{Func{TEntity, object}}"/>.
+        /// </param>
+        /// <returns>The <see cref="string"/>.</returns>
         public static string Resolve<TEntity>(Expression<Func<TEntity, object>> includeExpression)
         {
-            IEnumerable<LambdaExpression> Lambdas(LambdaExpression lambda)
+            static IEnumerable<LambdaExpression> Lambdas(LambdaExpression lambda)
             {
                 var method = lambda.Body as MethodCallExpression;
                 while (method != null)
@@ -39,7 +39,7 @@ namespace SpecificatR.Infrastructure.Internal
                 yield return lambda;
             }
 
-            IEnumerable<string> PropertyNames(IEnumerable<LambdaExpression> lambdas)
+            static IEnumerable<string> PropertyNames(IEnumerable<LambdaExpression> lambdas)
             {
                 foreach (LambdaExpression lambda in lambdas)
                 {

--- a/src/SpecificatR.Infrastructure/Internal/SpecificationEvaluator.cs
+++ b/src/SpecificatR.Infrastructure/Internal/SpecificationEvaluator.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="SpecificationEvaluator.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="SpecificationEvaluator.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:45</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Internal
@@ -13,10 +11,10 @@ namespace SpecificatR.Infrastructure.Internal
     using System.Linq;
     using System.Linq.Expressions;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
-    /// Defines the <see cref="SpecificationEvaluator{ClassType}" />.
+    /// Defines the <see cref="SpecificationEvaluator{ClassType}"/>.
     /// </summary>
     /// <typeparam name="TEntity">Class Entity type.</typeparam>
     internal class SpecificationEvaluator<TEntity>
@@ -25,8 +23,8 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// The GetQuery.
         /// </summary>
-        /// <param name="inputQuery">The inputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="inputQuery">   The inputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         internal static IQueryable<TEntity> GetQuery(IQueryable<TEntity> inputQuery, ISpecification<TEntity> specification)
         {
@@ -44,14 +42,16 @@ namespace SpecificatR.Infrastructure.Internal
 
             outputQuery = SetTracking(outputQuery, specification);
 
+            outputQuery = SetDistinct(outputQuery, specification);
+
             return outputQuery;
         }
 
         /// <summary>
         /// The GetQueryWithCount.
         /// </summary>
-        /// <param name="inputQuery">The inputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="inputQuery">   The inputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="(IQueryable{TEntity} query, int filteredCount)"/>.</returns>
         internal static (IQueryable<TEntity> query, int filteredCount) GetQueryWithCount(IQueryable<TEntity> inputQuery, ISpecification<TEntity> specification)
         {
@@ -71,14 +71,16 @@ namespace SpecificatR.Infrastructure.Internal
 
             outputQuery = SetTracking(outputQuery, specification);
 
+            outputQuery = SetDistinct(outputQuery, specification);
+
             return (outputQuery, filteredCount);
         }
 
         /// <summary>
         /// The SetCriteria.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="criteria">The criteria<see cref="Expression{Func{TEntity, bool}}"/>.</param>
+        /// <param name="outputQuery">The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="criteria">   The criteria <see cref="Expression{Func{TEntity, bool}}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetCriteria(IQueryable<TEntity> outputQuery, Expression<Func<TEntity, bool>> criteria)
         {
@@ -91,8 +93,8 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// The SetIgnoreQueryFilters.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="outputQuery">  The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetIgnoreQueryFilters(IQueryable<TEntity> outputQuery, ISpecification<TEntity> specification)
         {
@@ -105,8 +107,8 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// The SetIncludes.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="outputQuery">  The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetIncludes(IQueryable<TEntity> outputQuery, ISpecification<TEntity> specification)
         {
@@ -125,8 +127,8 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// The SetOrderBy.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="outputQuery">  The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetOrderBy(IQueryable<TEntity> outputQuery, ISpecification<TEntity> specification)
         {
@@ -155,8 +157,8 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// The SetPaging.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="outputQuery">  The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetPaging(IQueryable<TEntity> outputQuery, ISpecification<TEntity> specification)
         {
@@ -169,8 +171,8 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// The SetTracking.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="outputQuery">  The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetTracking(IQueryable<TEntity> outputQuery, ISpecification<TEntity> specification)
         {
@@ -183,15 +185,18 @@ namespace SpecificatR.Infrastructure.Internal
         /// <summary>
         /// Set Distinct on the query.
         /// </summary>
-        /// <param name="outputQuery">The outputQuery<see cref="IQueryable{ClassType}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{ClassType}"/>.</param>
+        /// <param name="outputQuery">The outputQuery <see cref="IQueryable{ClassType}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{ClassType}"/>.</param>
         /// <returns>The <see cref="IQueryable{ClassType}"/>.</returns>
         private static IQueryable<TEntity> SetDistinct(IQueryable<TEntity> outputQuery, ISpecification<TEntity> specification)
         {
-            if (specification.AsDistinct)
+            if (!specification.AsDistinct)
                 return outputQuery;
 
-            return outputQuery.Distinct();
+            if (specification.DistinctComparer == null)
+                return outputQuery.Distinct();
+
+            return outputQuery.Distinct(specification.DistinctComparer);
         }
     }
 }

--- a/src/SpecificatR.Infrastructure/Internal/SpecificationResolver.cs
+++ b/src/SpecificatR.Infrastructure/Internal/SpecificationResolver.cs
@@ -1,17 +1,15 @@
 //-----------------------------------------------------------------------
-// <copyright file="ApplySpecification.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="ApplySpecification.cs">>
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 18:51:47</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Internal
 {
     using System.Linq;
     using System.Threading.Tasks;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
     /// Defines the <see cref="ApplySpecification"/>.
@@ -26,16 +24,16 @@ namespace SpecificatR.Infrastructure.Internal
         /// <param name="inputQuery">   The inputQuery <see cref="IQueryable{TEntity}"/>.</param>
         /// <param name="specification">The specification <see cref="ISpecification{TEntity}"/>.</param>
         /// <returns>The <see cref="Task{TEntity[]}"/>.</returns>
-        public static TEntity[] GetResultSet(IQueryable<TEntity> inputQuery, ISpecification<TEntity> specification)
+        public static TEntity[] GetAllResult(IQueryable<TEntity> inputQuery, ISpecification<TEntity> specification)
             => ApplySpecification(inputQuery: inputQuery, specification: specification).ToArray();
 
         /// <summary>
         /// The GetSingleResultAsync.
         /// </summary>
-        /// <param name="inputQuery">The inputQuery<see cref="IQueryable{TEntity}"/>.</param>
-        /// <param name="specification">The specification<see cref="ISpecification{TEntity}"/>.</param>
+        /// <param name="inputQuery">   The inputQuery <see cref="IQueryable{TEntity}"/>.</param>
+        /// <param name="specification">The specification <see cref="ISpecification{TEntity}"/>.</param>
         /// <returns>The <see cref="TEntity"/>.</returns>
-        public static TEntity GetSingleResult(IQueryable<TEntity> inputQuery, ISpecification<TEntity> specification)
+        public static TEntity GetFirstOrDefaultResult(IQueryable<TEntity> inputQuery, ISpecification<TEntity> specification)
             => ApplySpecification(inputQuery: inputQuery, specification: specification).FirstOrDefault();
 
         /// <summary>

--- a/src/SpecificatR.Infrastructure/Repositories/IReadBaseRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/IReadBaseRepository.cs
@@ -1,17 +1,15 @@
 //-----------------------------------------------------------------------
-// <copyright file="IReadBaseRepository.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="IReadBaseRepository.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
     /// Defines the <see cref="IReadBaseRepository{TEntity, TIdentifier, TDbContext}"/>.

--- a/src/SpecificatR.Infrastructure/Repositories/IReadCoreRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/IReadCoreRepository.cs
@@ -1,17 +1,15 @@
 //-----------------------------------------------------------------------
-// <copyright file="IReadCoreRepository.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="IReadCoreRepository.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
     /// Defines the <see cref="IReadCoreRepository{TEntity, TDbContext}"/>.
@@ -37,42 +35,26 @@ namespace SpecificatR.Infrastructure.Repositories
         Task<TEntity[]> GetAll(ISpecification<TEntity> specification);
 
         /// <summary>
+        /// Get all entities as readonly objects. Using SqlQuery with Query params.
+        /// </summary>
+        /// <param name="sqlQuery">  Query string.</param>
+        /// <param name="parameters">Query parameters.</param>
+        /// <returns>The <see cref="TEntity[]"/>.</returns>
+        Task<TEntity[]> GetAll(string sqlQuery, params object[] parameters);
+
+        /// <summary>
+        /// Get single entity as readonly object. Using SqlQuery with Query params.
+        /// </summary>
+        /// <param name="sqlQuery">  Query string.</param>
+        /// <param name="parameters">Query parameters.</param>
+        /// <returns>The <see cref="TEntity"/>.</returns>
+        Task<TEntity> GetFirstOrDefault(string sqlQuery, params object[] parameters);
+
+        /// <summary>
         /// Get entity based on specification (Query object).
         /// </summary>
         /// <param name="specification">Specification parameter.</param>
         /// <returns>The <see cref="TEntity"/>.</returns>
-        Task<TEntity> GetSingleWithSpecification(ISpecification<TEntity> specification);
-
-        /// <summary>
-        /// Get all entities as readonly objects. Using SqlQuery with Query params.
-        /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
-        /// <param name="parameters">Query parameters.</param>
-        /// <returns>The <see cref="TEntity[]"/>.</returns>
-        Task<TEntity[]> GetByQueryFromDbSet(string sqlQuery, params object[] parameters);
-
-        /// <summary>
-        /// Get single entity as readonly object. Using SqlQuery with Query params.
-        /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
-        /// <param name="parameters">Query parameters.</param>
-        /// <returns>The <see cref="TEntity"/>.</returns>
-        Task<TEntity> GetSingleByQueryFromDbSet(string sqlQuery, params object[] parameters);
-
-        /// <summary>
-        /// Get all entities as readonly objects. Using SqlQuery with Query params.
-        /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
-        /// <param name="parameters">Query parameters.</param>
-        /// <returns>The <see cref="TEntity[]"/>.</returns>
-        Task<TEntity[]> GetByQueryFromQuerySet(string sqlQuery, params object[] parameters);
-
-        /// <summary>
-        /// Get single entity as readonly object. Using SqlQuery with Query params.
-        /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
-        /// <param name="parameters">Query parameters.</param>
-        /// <returns>The <see cref="TEntity"/>.</returns>
-        Task<TEntity> GetSingleByQueryFromQuerySet(string sqlQuery, params object[] parameters);
+        Task<TEntity> GetFirstOrDefault(ISpecification<TEntity> specification);
     }
 }

--- a/src/SpecificatR.Infrastructure/Repositories/IReadWriteBaseRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/IReadWriteBaseRepository.cs
@@ -7,13 +7,13 @@
 // <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
     /// Defines the <see cref="IReadWriteBaseRepository{TEntity, TIdentifier, TDbContext}" />.

--- a/src/SpecificatR.Infrastructure/Repositories/IReadWriteCoreRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/IReadWriteCoreRepository.cs
@@ -7,7 +7,7 @@
 // <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System;
     using System.Linq.Expressions;

--- a/src/SpecificatR.Infrastructure/Repositories/ReadBaseRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/ReadBaseRepository.cs
@@ -7,11 +7,11 @@
 // <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
     /// Defines the <see cref="ReadBaseRepository{TEntity, TIdentifier, TDbContext}"/>.

--- a/src/SpecificatR.Infrastructure/Repositories/ReadCoreRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/ReadCoreRepository.cs
@@ -7,13 +7,12 @@
 // <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using SpecificatR.Infrastructure.Abstractions;
+using SpecificatR.Abstractions;
 using SpecificatR.Infrastructure.Internal;
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     internal class ReadCoreRepository<TEntity, TDbContext> : IReadCoreRepository<TEntity, TDbContext>
         where TEntity : class
@@ -31,38 +30,11 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <summary>
         /// Get all from DbSet using FromSql.
         /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
+        /// <param name="sqlQuery">  Query string.</param>
         /// <param name="parameters">Query parameters.</param>
         /// <returns>The <see cref="TEntity[]"/>.</returns>
-        public async Task<TEntity[]> GetByQueryFromDbSet(string sqlQuery, params object[] parameters)
-            => await Context.Set<TEntity>().FromSql(sqlQuery, parameters).ToArrayAsync();
-
-        /// <summary>
-        /// Get single or default from DbSet using FromSql.
-        /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
-        /// <param name="parameters">Querye parameters.</param>
-        /// <returns>The <see cref="TEntity"/>.</returns>
-        public async Task<TEntity> GetSingleByQueryFromDbSet(string sqlQuery, params object[] parameters)
-            => await Context.Set<TEntity>().FromSql(sqlQuery, parameters).SingleOrDefaultAsync();
-
-        /// <summary>
-        /// Get all from Query set using FromSql.
-        /// </summary>
-        /// <param name="sqlQuery">Query string.</param>
-        /// <param name="parameters">Query parameters.</param>
-        /// <returns>The <see cref="TEntity[]"/>.</returns>
-        public async Task<TEntity[]> GetByQueryFromQuerySet(string sqlQuery, params object[] parameters)
-            => await Context.Query<TEntity>().FromSql(sqlQuery, parameters).ToArrayAsync();
-
-        /// <summary>
-        /// Get single or default from Query set using FromSql.
-        /// </summary>
-        /// <param name="sqlQuery">Guery string.</param>
-        /// <param name="parameters">Query parameters.</param>
-        /// <returns>The <see cref="TEntity"/>.</returns>
-        public async Task<TEntity> GetSingleByQueryFromQuerySet(string sqlQuery, params object[] parameters)
-            => await Context.Query<TEntity>().FromSql(sqlQuery, parameters).SingleOrDefaultAsync();
+        public async Task<TEntity[]> GetAll(string sqlQuery, params object[] parameters)
+            => await Context.Set<TEntity>().FromSqlRaw(sqlQuery, parameters).ToArrayAsync();
 
         /// <summary>
         /// The GetAllAsync.
@@ -83,14 +55,23 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <param name="specification">The specification <see cref="ISpecification{TEntity}"/>.</param>
         /// <returns>The <see cref="Task{TEntity[]}"/>.</returns>
         public async Task<TEntity[]> GetAll(ISpecification<TEntity> specification)
-            => await Task.FromResult(SpecificationResolver<TEntity>.GetResultSet(Context.Set<TEntity>().AsQueryable(), specification));
+            => await Task.FromResult(SpecificationResolver<TEntity>.GetAllResult(Context.Set<TEntity>().AsQueryable(), specification));
+
+        /// <summary>
+        /// Get single or default from DbSet using FromSql.
+        /// </summary>
+        /// <param name="sqlQuery">  Query string.</param>
+        /// <param name="parameters">Querye parameters.</param>
+        /// <returns>The <see cref="TEntity"/>.</returns>
+        public async Task<TEntity> GetFirstOrDefault(string sqlQuery, params object[] parameters)
+            => await Context.Set<TEntity>().FromSqlRaw(sqlQuery, parameters).FirstOrDefaultAsync();
 
         /// <summary>
         /// The GetSingleWithSpecificationAsync.
         /// </summary>
         /// <param name="specification">The specification <see cref="ISpecification{TEntity}"/>.</param>
         /// <returns>The <see cref="Task{TEntity}"/>.</returns>
-        public async Task<TEntity> GetSingleWithSpecification(ISpecification<TEntity> specification)
-            => await Task.FromResult(SpecificationResolver<TEntity>.GetSingleResult(Context.Set<TEntity>().AsQueryable(), specification));
+        public async Task<TEntity> GetFirstOrDefault(ISpecification<TEntity> specification)
+            => await Task.FromResult(SpecificationResolver<TEntity>.GetFirstOrDefaultResult(Context.Set<TEntity>().AsQueryable(), specification));
     }
 }

--- a/src/SpecificatR.Infrastructure/Repositories/ReadWriteBaseRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/ReadWriteBaseRepository.cs
@@ -7,16 +7,16 @@
 // <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     /// <summary>
-    /// Defines the <see cref="ReadWriteBaseRepository{TEntity, TIdentifier, TDbContext}" />.
+    /// Defines the <see cref="ReadWriteBaseRepository{TEntity, TIdentifier, TDbContext}"/>.
     /// </summary>
     /// <typeparam name="TEntity">The <see cref="TEntity"/>.</typeparam>
     /// <typeparam name="TIdentifier">The <see cref="TIdentifier"/>.</typeparam>
@@ -26,9 +26,10 @@ namespace SpecificatR.Infrastructure.Repositories
         where TDbContext : DbContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ReadWriteBaseRepository{TEntity, TIdentifier, TDbContext}"/> class.
+        /// Initializes a new instance of the <see cref="ReadWriteBaseRepository{TEntity,
+        /// TIdentifier, TDbContext}"/> class.
         /// </summary>
-        /// <param name="context">The context<see cref="TDbContext"/>.</param>
+        /// <param name="context">The context <see cref="TDbContext"/>.</param>
         public ReadWriteBaseRepository(TDbContext context)
             : base(context)
         {
@@ -37,7 +38,7 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <summary>
         /// The DeleteByIdAsync.
         /// </summary>
-        /// <param name="id">The id<see cref="TIdentifier"/>.</param>
+        /// <param name="id">The id <see cref="TIdentifier"/>.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task DeleteById(TIdentifier id)
         {
@@ -54,7 +55,7 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <summary>
         /// The AddAsync.
         /// </summary>
-        /// <param name="entity">The entity<see cref="TEntity"/>.</param>
+        /// <param name="entity">The entity <see cref="TEntity"/>.</param>
         /// <returns>The <see cref="Task{TEntity}"/>.</returns>
         public async Task<TEntity> Add(TEntity entity)
         {
@@ -68,7 +69,7 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <summary>
         /// The DeleteAsync.
         /// </summary>
-        /// <param name="entity">The entity<see cref="TEntity"/>.</param>
+        /// <param name="entity">The entity <see cref="TEntity"/>.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         public Task Delete(TEntity entity)
         {
@@ -82,7 +83,7 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <summary>
         /// The UpdateAsync.
         /// </summary>
-        /// <param name="entity">The entity<see cref="TEntity"/>.</param>
+        /// <param name="entity">The entity <see cref="TEntity"/>.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         public Task Update(TEntity entity)
         {
@@ -114,8 +115,8 @@ namespace SpecificatR.Infrastructure.Repositories
         /// <summary>
         /// The UpdateFieldsAsync.
         /// </summary>
-        /// <param name="entity">The entity<see cref="TEntity"/>.</param>
-        /// <param name="properties">The properties<see cref="Expression{Func{TEntity, object}}[]"/>.</param>
+        /// <param name="entity">    The entity <see cref="TEntity"/>.</param>
+        /// <param name="properties">The properties <see cref="Expression{Func{TEntity, object}}[]"/>.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         public Task UpdateFields(TEntity entity, params Expression<Func<TEntity, object>>[] properties)
         {

--- a/src/SpecificatR.Infrastructure/Repositories/ReadWriteCoreRepository.cs
+++ b/src/SpecificatR.Infrastructure/Repositories/ReadWriteCoreRepository.cs
@@ -7,7 +7,7 @@
 // <date>25/05/2019 10:10:44</date>
 //-----------------------------------------------------------------------
 
-namespace SpecificatR.Infrastructure.Repositories
+namespace SpecificatR
 {
     using System;
     using System.Linq.Expressions;

--- a/src/SpecificatR.Infrastructure/SpecificatR.Infrastructure.csproj
+++ b/src/SpecificatR.Infrastructure/SpecificatR.Infrastructure.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>Latest</LangVersion>
-    <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>SpecificatR</PackageId>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>David Vanderheyden</Authors>
-    <Product>SpecificatR</Product>
-    <Description>SpecificatR contains generic repositories (Read/ReadWrite) and interfaces for building a database infrastructure using EntityFramework Core and following the Specification Pattern</Description>
-    <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
+    <Description>SpecificatR contains generic repositories (Read/ReadWrite) for building a database infrastructure using EntityFramework Core 3.1 and using the Specification Pattern to create query models</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>Latest</LangVersion>
+    <PackageId>SpecificatR</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Product>SpecificatR</Product>
+    <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
+    <Version>3.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/SpecificatR.Infrastructure/SpecificatR.Infrastructure.csproj
+++ b/src/SpecificatR.Infrastructure/SpecificatR.Infrastructure.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>Latest</LangVersion>
     <PackageId>SpecificatR</PackageId>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>SpecificatR</Product>
     <RepositoryUrl>https://github.com/Cr3ature/SpecificatR</RepositoryUrl>
     <Version>3.0.0.0</Version>

--- a/tests/SpecificatR.Infrastructure.Tests/Repositories/IncludeExpressionResolverTests.cs
+++ b/tests/SpecificatR.Infrastructure.Tests/Repositories/IncludeExpressionResolverTests.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="IncludeExpressionResolverTests.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="IncludeExpressionResolverTests.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:47</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Tests
@@ -16,7 +14,7 @@ namespace SpecificatR.Infrastructure.Tests
     using Xunit;
 
     /// <summary>
-    /// Defines the <see cref="IncludeExpressionResolverTests" />.
+    /// Defines the <see cref="IncludeExpressionResolverTests"/>.
     /// </summary>
     public class IncludeExpressionResolverTests
     {
@@ -73,7 +71,7 @@ namespace SpecificatR.Infrastructure.Tests
         }
 
         /// <summary>
-        /// Defines the <see cref="Entity" />.
+        /// Defines the <see cref="Entity"/>.
         /// </summary>
         private sealed class Entity
         {
@@ -94,7 +92,7 @@ namespace SpecificatR.Infrastructure.Tests
         }
 
         /// <summary>
-        /// Defines the <see cref="NestedEntity" />.
+        /// Defines the <see cref="NestedEntity"/>.
         /// </summary>
         private sealed class NestedEntity
         {
@@ -110,7 +108,7 @@ namespace SpecificatR.Infrastructure.Tests
         }
 
         /// <summary>
-        /// Defines the <see cref="NestedNestedEntity" />.
+        /// Defines the <see cref="NestedNestedEntity"/>.
         /// </summary>
         private sealed class NestedNestedEntity
         {

--- a/tests/SpecificatR.Infrastructure.Tests/Repositories/ReadBaseRepositoryTests.cs
+++ b/tests/SpecificatR.Infrastructure.Tests/Repositories/ReadBaseRepositoryTests.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="ReadRepositoryTests.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="ReadRepositoryTests.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:48</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Tests.Repositories
@@ -13,16 +11,17 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
     using System.Linq;
     using System.Threading.Tasks;
     using AutoFixture;
-    using EntityFrameworkCoreMock;
+    using EntityFrameworkCore3Mock;
     using FluentAssertions;
     using Microsoft.EntityFrameworkCore;
     using Moq;
-    using SpecificatR.Infrastructure.Abstractions;
-    using SpecificatR.Infrastructure.Repositories;
+    using SpecificatR;
+    using SpecificatR.Abstractions;
+    using SpecificatR.Infrastructure.Tests.Specifications;
     using Xunit;
 
     /// <summary>
-    /// Defines the <see cref="ReadBaseRepositoryTests" />.
+    /// Defines the <see cref="ReadBaseRepositoryTests"/>.
     /// </summary>
     public class ReadBaseRepositoryTests
     {
@@ -128,8 +127,9 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
             TestEntity result = await repository.GetById(entities[0].Id, true);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Should().BeEquivalentTo(entities[0]);
+            result.Should()
+                .NotBeNull().And
+                .BeEquivalentTo(entities[0]);
         }
 
         /// <summary>
@@ -144,16 +144,19 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
 
             var dbContextMock = new DbContextMock<TestDbContext>(_options);
             dbContextMock.CreateDbSetMock(x => x.TestEntities, (x, _) => x.Id, entities);
+            dbContextMock.Setup(s => s.Set<TestEntity>().AsQueryable()).Returns(entities.AsQueryable());
             var repository = new ReadBaseRepository<TestEntity, Guid, TestDbContext>(dbContextMock.Object);
 
-            var specification = new Mock<ISpecification<TestEntity>>();
+            var specification = new TestEntityByIdSpecification(entities[0].Id);
 
             // Act
-            TestEntity result = await repository.GetSingleWithSpecification(specification.Object);
+            TestEntity result = await repository.GetFirstOrDefault(specification);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Should().BeOfType(typeof(TestEntity));
+            result.Should()
+                .NotBeNull().And
+                .BeOfType(typeof(TestEntity)).And
+                .BeEquivalentTo(entities[0]);
         }
 
         /// <summary>
@@ -174,8 +177,9 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
             TestEntity[] result = await repository.GetAll();
 
             // Assert
-            result.Should().NotBeNull();
-            result.Should().HaveCount(2);
+            result.Should()
+                .NotBeNull().And
+                .HaveCount(2);
         }
 
         /// <summary>
@@ -196,8 +200,9 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
             TestEntity[] result = await repository.GetAll(true);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Should().HaveCount(2);
+            result.Should()
+                .NotBeNull().And
+                .HaveCount(2);
         }
 
         /// <summary>
@@ -212,6 +217,7 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
 
             var dbContextMock = new DbContextMock<TestDbContext>(_options);
             dbContextMock.CreateDbSetMock(x => x.TestEntities, (x, _) => x.Id, entities);
+            dbContextMock.Setup(s => s.Set<TestEntity>().AsQueryable()).Returns(entities.AsQueryable());
             var repository = new ReadBaseRepository<TestEntity, Guid, TestDbContext>(dbContextMock.Object);
 
             var specification = new Mock<ISpecification<TestEntity>>();
@@ -220,8 +226,10 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
             TestEntity[] result = await repository.GetAll(specification.Object);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Should().BeOfType(typeof(TestEntity[]));
+            result.Should()
+                .NotBeEmpty().And
+                .BeOfType(typeof(TestEntity[])).And
+                .BeEquivalentTo(entities);
         }
     }
 }

--- a/tests/SpecificatR.Infrastructure.Tests/Repositories/ReadWriteBaseRepositoryTests.cs
+++ b/tests/SpecificatR.Infrastructure.Tests/Repositories/ReadWriteBaseRepositoryTests.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="ReadWriteRepositoryTests.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="ReadWriteRepositoryTests.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 10:10:48</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Tests.Repositories
@@ -13,14 +11,14 @@ namespace SpecificatR.Infrastructure.Tests.Repositories
     using System.Linq;
     using System.Threading.Tasks;
     using AutoFixture;
-    using EntityFrameworkCoreMock;
+    using EntityFrameworkCore3Mock;
     using FluentAssertions;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Repositories;
+    using SpecificatR;
     using Xunit;
 
     /// <summary>
-    /// Defines the <see cref="ReadWriteBaseRepositoryTests" />.
+    /// Defines the <see cref="ReadWriteBaseRepositoryTests"/>.
     /// </summary>
     public class ReadWriteBaseRepositoryTests
     {

--- a/tests/SpecificatR.Infrastructure.Tests/SpecificatR.Infrastructure.Tests.csproj
+++ b/tests/SpecificatR.Infrastructure.Tests/SpecificatR.Infrastructure.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
-    <PackageReference Include="EntityFrameworkCoreMock.Moq" Version="1.0.0.25" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="EntityFrameworkCore3Mock.Moq" Version="1.0.0.3" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.2" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/tests/SpecificatR.Infrastructure.Tests/Specifications/SpecificationTests.cs
+++ b/tests/SpecificatR.Infrastructure.Tests/Specifications/SpecificationTests.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="SpecificationTests.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="SpecificationTests.cs"
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 17:47:14</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Tests
@@ -15,9 +13,8 @@ namespace SpecificatR.Infrastructure.Tests
     using System.Threading.Tasks;
     using AutoFixture;
     using FluentAssertions;
-    using Microsoft.EntityFrameworkCore;
     using SpecificatR.Infrastructure.Tests.Specifications;
-    using SpecificatR.Infrastructure.UnitTest.Abstractions;
+    using SpecificatR.UnitTest.Abstractions;
     using Xunit;
 
     /// <summary>
@@ -29,11 +26,6 @@ namespace SpecificatR.Infrastructure.Tests
         /// Defines the _fixture.
         /// </summary>
         private readonly IFixture _fixture = new Fixture();
-
-        /// <summary>
-        /// Defines the _options.
-        /// </summary>
-        private readonly DbContextOptions<TestDbContext> _options = new DbContextOptions<TestDbContext>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecificationTests"/> class.
@@ -155,7 +147,7 @@ namespace SpecificatR.Infrastructure.Tests
                 .Without(wh => wh.Children)
                 .CreateMany(5);
 
-            List<TestEntity> testEntities = new List<TestEntity>();
+            var testEntities = new List<TestEntity>();
             testEntities.AddRange(testEntitiesWithoutChildren);
             testEntities.AddRange(testEntitiesWithChild);
 

--- a/tests/SpecificatR.Infrastructure.Tests/Specifications/TestSpecifications.cs
+++ b/tests/SpecificatR.Infrastructure.Tests/Specifications/TestSpecifications.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="TestSpecifications.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="TestSpecifications.cs">
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 17:46:12</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Tests.Specifications
@@ -12,7 +10,7 @@ namespace SpecificatR.Infrastructure.Tests.Specifications
     using System;
     using System.Linq;
     using System.Linq.Expressions;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
 #pragma warning disable SA1649 // File name should match first type name
 

--- a/tests/SpecificatR.Infrastructure.Tests/TestDbContext.cs
+++ b/tests/SpecificatR.Infrastructure.Tests/TestDbContext.cs
@@ -1,10 +1,8 @@
 //-----------------------------------------------------------------------
-// <copyright file="TestDbContext.cs" company="David Vanderheyden">
-//     Copyright (c) 2019 All Rights Reserved
+// <copyright file="TestDbContext.cs" >
+//     Copyright (c) 2019-2020 David Vanderheyden All Rights Reserved
 // </copyright>
 // <licensed>Distributed under Apache-2.0 license</licensed>
-// <author>David Vanderheyden</author>
-// <date>25/05/2019 11:04:30</date>
 //-----------------------------------------------------------------------
 
 namespace SpecificatR.Infrastructure.Tests
@@ -12,7 +10,7 @@ namespace SpecificatR.Infrastructure.Tests
     using System;
     using System.Collections.Generic;
     using Microsoft.EntityFrameworkCore;
-    using SpecificatR.Infrastructure.Abstractions;
+    using SpecificatR.Abstractions;
 
     public class TestDbContext : DbContext
     {


### PR DESCRIPTION
Simplify namespaces - Add support to use own created or default comparers with distinct - Migrate EFCore 2.2 to 3.0